### PR TITLE
feat: Add withdrawal message verification

### DIFF
--- a/x/gmm/types/errors.go
+++ b/x/gmm/types/errors.go
@@ -30,4 +30,5 @@ var (
 	ErrInvalidAmp               = sdkerrors.Register(ModuleName, 1120, "amp has to be zero to 100")
 	ErrNotMeetSlippage          = sdkerrors.Register(ModuleName, 1121, "not meet slippage")
 	ErrInvalidSlippage          = sdkerrors.Register(ModuleName, 1122, "invalid slippage")
+	ErrMismatchedShareDenom     = sdkerrors.Register(ModuleName, 1123, "mismatched share denom")
 )

--- a/x/gmm/types/message_withdraw.go
+++ b/x/gmm/types/message_withdraw.go
@@ -62,5 +62,9 @@ func (msg *MsgWithdraw) ValidateBasic() error {
 	if msg.Share.Amount.IsZero() {
 		return sdkerrors.Wrap(ErrInvalidTokenAmount, "share amount cannot be zero")
 	}
+
+	if msg.PoolId != msg.Share.GetDenom() {
+		return sdkerrors.Wrapf(ErrMismatchedShareDenom, "share denom and pool id do not match")
+	}
 	return nil
 }

--- a/x/gmm/types/message_withdraw_test.go
+++ b/x/gmm/types/message_withdraw_test.go
@@ -52,13 +52,26 @@ func TestMsgWithdraw_ValidateBasic(t *testing.T) {
 			err: ErrInvalidTokenAmount,
 		},
 		{
-			name: "valid message",
+			name: "mismatched share denom",
 			msg: MsgWithdraw{
 				Sender:   sample.AccAddress(),
 				Receiver: sample.AccAddress(),
 				PoolId:   "test1",
 				Share: sdk.NewCoin(
 					"test",
+					sdk.NewInt(1),
+				),
+			},
+			err: ErrMismatchedShareDenom,
+		},
+		{
+			name: "valid message",
+			msg: MsgWithdraw{
+				Sender:   sample.AccAddress(),
+				Receiver: sample.AccAddress(),
+				PoolId:   "test1",
+				Share: sdk.NewCoin(
+					"test1",
 					sdk.NewInt(10),
 				),
 			},


### PR DESCRIPTION
The original code did not check whether the `poolId` and `denom` of `msg` matched in the `Withdraw` function, leading to a vulnerability. Assuming Alice has two shares, ShareA and ShareB, when calling Withdraw, Alice sets the `poolId` in `msg` to the liquidity pool corresponding to ShareA but sets the `denom` to the `denom` of ShareB. In this case, the following code will not throw an error. 
https://github.com/sideprotocol/side/blob/47fc3fe9642c316865b5d3f8e07a1c1389a24029/x/gmm/keeper/msg_server_withdraw.go#L28-L30
In the end, Alice will successfully obtain tokens from the liquidity pool of PoolA by decreasing the shares of PoolB.