### PR TITLE
refactor: remove ValidateBasic in cli

### DIFF
--- a/x/gmm/client/cli/tx_add_liquidity.go
+++ b/x/gmm/client/cli/tx_add_liquidity.go
@@ -34,9 +34,7 @@ func CmdAddLiquidity() *cobra.Command {
 				args[0],
 				liquidity,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/gmm/client/cli/tx_create_pool.go
+++ b/x/gmm/client/cli/tx_create_pool.go
@@ -77,9 +77,7 @@ func CmdCreatePool() *cobra.Command {
 				},
 				liquidity,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/gmm/client/cli/tx_swap.go
+++ b/x/gmm/client/cli/tx_swap.go
@@ -38,9 +38,7 @@ func CmdSwap() *cobra.Command {
 				tokenIn,
 				tokenOut,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/gmm/client/cli/tx_withdraw.go
+++ b/x/gmm/client/cli/tx_withdraw.go
@@ -35,9 +35,7 @@ func CmdWithdraw() *cobra.Command {
 				args[1],
 				share,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}


### PR DESCRIPTION
The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. Related PRs can be viewed at: https://github.com/cosmos/cosmos-sdk/pull/9236#discussion_r623803504